### PR TITLE
Limit to 16 entries when reading and update chordCount. Update Waveform 8 when changing waveforms.

### DIFF
--- a/Chord-Organ/Chord-Organ.ino
+++ b/Chord-Organ/Chord-Organ.ino
@@ -486,6 +486,9 @@ void readSDSettings(){
             entry++;
             note = 0;
             inBracket = false;
+            if(entry == 16) {
+            	break;
+            }
         }
 
         else if (inBracket && character != '[' && character != ',' && character != ']'){
@@ -493,6 +496,7 @@ void readSDSettings(){
         }
 
     }   
+    chordCount = entry;
     settingsFile.close();
 }
 

--- a/Chord-Organ/Chord-Organ.ino
+++ b/Chord-Organ/Chord-Organ.ino
@@ -352,7 +352,7 @@ void updateSines(){
     waveform5.frequency(FREQ[4]);
     waveform6.frequency(FREQ[5]);
     waveform7.frequency(FREQ[6]);
-    waveform7.frequency(FREQ[7]);
+    waveform8.frequency(FREQ[7]);
 
 
     AudioInterrupts();


### PR DESCRIPTION
Prevent reading more than 16 chords from the text file and then update the chordCount variable so that CHORD Knob / CV maps across all available chords.